### PR TITLE
Automatically select fabric/forge for install

### DIFF
--- a/minecraft_mod_manager/app/install/install.py
+++ b/minecraft_mod_manager/app/install/install.py
@@ -1,6 +1,7 @@
-from typing import List, Sequence
+from typing import Dict, List, Sequence
 
 from ...core.entities.mod import Mod, ModArg
+from ...core.entities.mod_loaders import ModLoaders
 from ...utils.logger import LogColors, Logger
 from ..download.download import Download
 from .install_repo import InstallRepo
@@ -13,6 +14,7 @@ class Install(Download):
 
     def execute(self, mods: Sequence[ModArg]) -> None:
         mods = self._filter_installed_mods(mods)
+        mods = self._set_mod_loader(mods)
         self.find_download_and_install(mods)
 
     def _filter_installed_mods(self, mods: Sequence[ModArg]) -> Sequence[Mod]:
@@ -25,3 +27,37 @@ class Install(Download):
                 Logger.info(f"{mod.id} has already been installed, skipping...", LogColors.skip)
 
         return mods_to_install
+
+    def _set_mod_loader(self, mods: Sequence[Mod]) -> Sequence[Mod]:
+        loader = self._get_mod_loader_to_use()
+        if loader != ModLoaders.unknown:
+            for mod in mods:
+                mod.mod_loader = loader
+        return mods
+
+    def _get_mod_loader_to_use(self) -> ModLoaders:
+        mods = self._repo.get_all_mods()
+
+        # Count
+        counts: Dict[ModLoaders, int] = {}
+        for mod in mods:
+            loader = mod.mod_loader
+            if loader != ModLoaders.unknown:
+                count = 0
+                if loader in counts:
+                    count = counts[loader]
+                counts[loader] = count + 1
+
+        # Sort
+        count_max = 0
+        loader_max = ModLoaders.unknown
+
+        for loader, count in counts.items():
+            if count > count_max:
+                count_max = count
+                loader_max = loader
+            # Multiple max, use none then
+            elif count == count_max:
+                loader_max = ModLoaders.unknown
+
+        return loader_max

--- a/minecraft_mod_manager/app/install/install_repo.py
+++ b/minecraft_mod_manager/app/install/install_repo.py
@@ -1,6 +1,12 @@
+from typing import Sequence
+
+from ...core.entities.mod import Mod
 from ..download.download_repo import DownloadRepo
 
 
 class InstallRepo(DownloadRepo):
     def is_installed(self, id: str) -> bool:
+        raise NotImplementedError()
+
+    def get_all_mods(self) -> Sequence[Mod]:
         raise NotImplementedError()


### PR DESCRIPTION
### What changed?
Now automatically selects fabric/forge for install depending on majority. If two or more mod loaders have the same count of installments then it doesn't select any of them.

### Testing
- [X] Added unit tests

### Related Issues
Fixes #18
