### PR TITLE
Doesn't show unknown, and fix list alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.4] - ???
+## [1.0.4] - 2021-04-29
 
 ### Fixed
 
 - Reinstalling a mod after deleting it manually #33
+- Using `minecraft-mod-manager list` now doesn't display site if none is set
+- Using `minecraft-mod-manager list` didn't align properly if no slug was set
+- Changed `Alias` to `Slug` when using `list` command (to be consistent)
 
 ## [1.0.3] - 2021-04-25
 

--- a/minecraft_mod_manager/app/show/show.py
+++ b/minecraft_mod_manager/app/show/show.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 from ...core.entities.mod import Mod
+from ...core.entities.sites import Sites
 from ...utils.logger import LogColors, Logger
 from .show_repo import ShowRepo
 
@@ -10,20 +11,21 @@ class Show:
 
     def __init__(self, show_repo: ShowRepo) -> None:
         self._repo = show_repo
-        self._id_width = 0
-        self._repo_alias_width = 0
-        self._repo_site_width = 0
+        # Using width of headers as a minimum
+        self._id_width = 3
+        self._site_slug_width = 4
+        self._site_width = 4
         self._update_time_width = len("YYYY-MM-DD")
 
     def execute(self) -> None:
         self._installed_mods = self._repo.get_all_mods()
 
         self._calculate_id_width()
-        self._calculate_repo_alias_width()
+        self._calculate_repo_slug_width()
         self._calculate_repo_site_width()
 
         self._print_header()
-        self._print_row("Mod", "Alias", "Site", "Published")
+        self._print_row("Mod", "Slug", "Site", "Published")
         for mod in self._installed_mods:
             self._print_mod(mod)
 
@@ -33,31 +35,34 @@ class Show:
                 self._id_width = len(mod.id)
         self._id_width += Show._padding
 
-    def _calculate_repo_alias_width(self) -> None:
+    def _calculate_repo_slug_width(self) -> None:
         for mod in self._installed_mods:
-            # Make sure we display an empty alias instead of 'None'
+            # Make sure we display an empty slug instead of 'None'
             if not mod.site_slug:
                 mod.site_slug = ""
 
-            if len(mod.site_slug) > self._repo_alias_width:
-                self._repo_alias_width = len(mod.site_slug)
+            if len(mod.site_slug) > self._site_slug_width:
+                self._site_slug_width = len(mod.site_slug)
 
-        self._repo_alias_width += Show._padding
+        self._site_slug_width += Show._padding
 
     def _calculate_repo_site_width(self) -> None:
         for mod in self._installed_mods:
-            if len(mod.site.value) > self._repo_site_width:
-                self._repo_site_width = len(mod.site.value)
-        self._repo_site_width += Show._padding
+            if mod.site != Sites.unknown and len(mod.site.value) > self._site_width:
+                self._site_width = len(mod.site.value)
+        self._site_width += Show._padding
 
     def _print_header(self) -> None:
         Logger.info(f"{LogColors.bold}Installed mods:{LogColors.no_color}")
 
-    def _print_row(self, id, alias, site, published) -> None:
+    def _print_row(self, id, slug, site, published) -> None:
+        if site == "unknown":
+            site = ""
+
         print(
             f"{id}".ljust(self._id_width)
-            + f"{alias}".ljust(self._repo_alias_width)
-            + f"{site}".ljust(self._repo_site_width)
+            + f"{slug}".ljust(self._site_slug_width)
+            + f"{site}".ljust(self._site_width)
             + f"{published}"
         )
 


### PR DESCRIPTION
### What changed?
- `list` now uses "slug" instead of "alias"
- `list` now formats the table correctly, even if no mod, slug or site is avaialable.
- `list` now only displays site for those that have been set, and empty if not (was: unknown)

### Testing

- [ ] Added unit tests
- [X] Ran the command manually without any slug and site to see that it formats things correctly

### Related Issues

Fixes #34
