### PR TITLE
🐛 Fix ability to download mods without mod loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Upcoming]
+
+### Fixed
+
+- Can now install mods that don't specify a mod loader [#35](https://github.com/Senth/minecraft-mod-manager/issues/35)
+
 ## [1.0.4] - 2021-04-29
 
 ### Fixed

--- a/minecraft_mod_manager/core/utils/latest_version_finder.py
+++ b/minecraft_mod_manager/core/utils/latest_version_finder.py
@@ -46,8 +46,28 @@ class LatestVersionFinder:
 
     @staticmethod
     def _is_filtered_by_mod_loader(prev: ModLoaders, version: VersionInfo) -> bool:
-        if config.filter.loader == ModLoaders.unknown:
+        """Check whether this version should be filtered by mod_loader.
+        Will check both if a global filter has been set, otherwise it will match against
+        the already install version's mod loader (if one exists).
+
+        Args:
+            prev (ModLoaders): The mod loader of the existing installed version
+            version (VersionInfo): Downloaded version to filter
+
+        Returns:
+            bool: True -> filter/remove; false -> keep it
+        """
+        # No mod loaders specified in version, match all
+        if len(version.mod_loaders) == 0:
+            return False
+
+        # Use global filter
+        elif config.filter.loader != ModLoaders.unknown:
+            return config.filter.loader not in version.mod_loaders
+
+        # Use filter from previous version
+        else:
             if prev != ModLoaders.unknown:
                 return prev not in version.mod_loaders
-            return False
-        return config.filter.loader not in version.mod_loaders
+
+        return False

--- a/minecraft_mod_manager/core/utils/latest_version_finder_test.py
+++ b/minecraft_mod_manager/core/utils/latest_version_finder_test.py
@@ -21,7 +21,7 @@ class Filter:
 
 class Test:
     def __init__(
-        self, name: str, mod: Mod, versions: List[VersionInfo], expected: VersionInfo, filter=Filter()
+        self, name: str, mod: Mod, versions: List[VersionInfo], expected: Union[VersionInfo, None], filter=Filter()
     ) -> None:
         self.name = name
         self.mod = mod
@@ -139,7 +139,6 @@ def reset_filter() -> None:
                     version_info(uploaded=10, mod_loaders=[ModLoaders.forge]),
                     version_info(uploaded=20, mod_loaders=[ModLoaders.fabric]),
                     version_info(uploaded=30, mod_loaders=[ModLoaders.forge]),
-                    version_info(uploaded=50, versions=["1.16.5"]),
                     version_info(uploaded=40, mod_loaders=[ModLoaders.fabric]),
                 ],
                 filter=Filter(loader=ModLoaders.forge),
@@ -153,12 +152,11 @@ def reset_filter() -> None:
                 versions=[
                     version_info(uploaded=10, mod_loaders=[ModLoaders.forge]),
                     version_info(uploaded=20, mod_loaders=[ModLoaders.fabric]),
-                    version_info(uploaded=30, mod_loaders=[ModLoaders.forge]),
-                    version_info(uploaded=50, versions=["1.16.5"]),
-                    version_info(uploaded=40, mod_loaders=[ModLoaders.fabric]),
+                    version_info(uploaded=40, mod_loaders=[ModLoaders.forge]),
+                    version_info(uploaded=30, mod_loaders=[ModLoaders.fabric]),
                 ],
                 filter=Filter(loader=ModLoaders.fabric),
-                expected=version_info(uploaded=40, mod_loaders=[ModLoaders.fabric]),
+                expected=version_info(uploaded=30, mod_loaders=[ModLoaders.fabric]),
             )
         ),
         (
@@ -169,7 +167,6 @@ def reset_filter() -> None:
                     version_info(uploaded=10, mod_loaders=[ModLoaders.forge]),
                     version_info(uploaded=20, mod_loaders=[ModLoaders.fabric]),
                     version_info(uploaded=30, mod_loaders=[ModLoaders.forge]),
-                    version_info(uploaded=50, versions=["1.16.5"]),
                     version_info(uploaded=40, mod_loaders=[ModLoaders.fabric]),
                 ],
                 expected=version_info(uploaded=30, mod_loaders=[ModLoaders.forge]),
@@ -180,13 +177,26 @@ def reset_filter() -> None:
                 name="Find latest version filter by mod loader in mod",
                 mod=mod(loader=ModLoaders.fabric),
                 versions=[
-                    version_info(uploaded=10, mod_loaders=[ModLoaders.forge]),
+                    version_info(uploaded=40, mod_loaders=[ModLoaders.forge]),
                     version_info(uploaded=20, mod_loaders=[ModLoaders.fabric]),
-                    version_info(uploaded=30, mod_loaders=[ModLoaders.forge, ModLoaders.fabric]),
-                    version_info(uploaded=50, versions=["1.16.5"]),
-                    version_info(uploaded=40, mod_loaders=[ModLoaders.fabric]),
+                    version_info(uploaded=20, mod_loaders=[ModLoaders.forge, ModLoaders.fabric]),
+                    version_info(uploaded=30, mod_loaders=[ModLoaders.fabric]),
                 ],
-                expected=version_info(uploaded=40, mod_loaders=[ModLoaders.fabric]),
+                expected=version_info(uploaded=30, mod_loaders=[ModLoaders.fabric]),
+            )
+        ),
+        (
+            Test(
+                name="Find latest version filter by mod loader in mod when loader is specified in version_info",
+                mod=mod(loader=ModLoaders.fabric),
+                versions=[
+                    version_info(uploaded=50, mod_loaders=[ModLoaders.forge]),
+                    version_info(uploaded=20, mod_loaders=[ModLoaders.fabric]),
+                    version_info(uploaded=20, mod_loaders=[ModLoaders.forge, ModLoaders.fabric]),
+                    version_info(uploaded=30, mod_loaders=[ModLoaders.fabric]),
+                    version_info(uploaded=40),
+                ],
+                expected=version_info(uploaded=40),
             )
         ),
         (
@@ -196,11 +206,10 @@ def reset_filter() -> None:
                 versions=[
                     version_info(uploaded=10, mod_loaders=[ModLoaders.forge]),
                     version_info(uploaded=20, mod_loaders=[ModLoaders.fabric]),
-                    version_info(uploaded=30, mod_loaders=[ModLoaders.forge]),
-                    version_info(uploaded=50, versions=["1.16.5"]),
-                    version_info(uploaded=40, mod_loaders=[ModLoaders.forge, ModLoaders.fabric]),
+                    version_info(uploaded=40, mod_loaders=[ModLoaders.forge]),
+                    version_info(uploaded=30, mod_loaders=[ModLoaders.forge, ModLoaders.fabric]),
                 ],
-                expected=version_info(uploaded=40, mod_loaders=[ModLoaders.forge, ModLoaders.fabric]),
+                expected=version_info(uploaded=30, mod_loaders=[ModLoaders.forge, ModLoaders.fabric]),
             )
         ),
         (
@@ -211,7 +220,6 @@ def reset_filter() -> None:
                     version_info(uploaded=10, mod_loaders=[ModLoaders.forge]),
                     version_info(uploaded=20, mod_loaders=[ModLoaders.fabric]),
                     version_info(uploaded=30, mod_loaders=[ModLoaders.forge]),
-                    version_info(uploaded=50, versions=["1.16.5"]),
                     version_info(uploaded=40, mod_loaders=[ModLoaders.fabric]),
                 ],
                 filter=Filter(loader=ModLoaders.forge),
@@ -225,12 +233,26 @@ def reset_filter() -> None:
                 versions=[
                     version_info(uploaded=10, mod_loaders=[ModLoaders.forge]),
                     version_info(uploaded=20, mod_loaders=[ModLoaders.fabric]),
-                    version_info(uploaded=30, mod_loaders=[ModLoaders.forge]),
-                    version_info(uploaded=50, versions=["1.16.5"]),
-                    version_info(uploaded=40, mod_loaders=[ModLoaders.fabric]),
+                    version_info(uploaded=40, mod_loaders=[ModLoaders.forge]),
+                    version_info(uploaded=30, mod_loaders=[ModLoaders.fabric]),
                 ],
                 filter=Filter(loader=ModLoaders.fabric),
-                expected=version_info(uploaded=40, mod_loaders=[ModLoaders.fabric]),
+                expected=version_info(uploaded=30, mod_loaders=[ModLoaders.fabric]),
+            )
+        ),
+        (
+            Test(
+                name="Find latest version filter by mod loader override mod when loader is specified in version_info",
+                mod=mod(),
+                versions=[
+                    version_info(uploaded=50, mod_loaders=[ModLoaders.forge]),
+                    version_info(uploaded=20, mod_loaders=[ModLoaders.fabric]),
+                    version_info(uploaded=20, mod_loaders=[ModLoaders.forge, ModLoaders.fabric]),
+                    version_info(uploaded=30, mod_loaders=[ModLoaders.fabric]),
+                    version_info(uploaded=40),
+                ],
+                filter=Filter(loader=ModLoaders.fabric),
+                expected=version_info(uploaded=40),
             )
         ),
         (
@@ -282,6 +304,20 @@ def reset_filter() -> None:
                     stability=Stabilities.beta,
                     versions=["1.16.5"],
                 ),
+            )
+        ),
+        (
+            Test(
+                name="Find no mod found using filters",
+                mod=mod(),
+                versions=[
+                    version_info(uploaded=10, mod_loaders=[ModLoaders.forge], versions=["1.16.4"]),
+                    version_info(uploaded=20, mod_loaders=[ModLoaders.fabric], versions=["1.16.5"]),
+                    version_info(uploaded=40, mod_loaders=[ModLoaders.forge]),
+                    version_info(uploaded=30, mod_loaders=[ModLoaders.fabric], versions=["1.16.2", "1.16.5"]),
+                ],
+                filter=Filter(loader=ModLoaders.forge, version="1.16.5"),
+                expected=None,
             )
         ),
     ],


### PR DESCRIPTION
Can now download mods that don't specify a mod loader

### What changed?
- Doesn't filter out `VersionInfo` if it has no mod_loader specified. It now treats it as match-all
- Also added a unit test for testing that we should not match anything.

### Testing
- [X] Added unit tests

### Related Issues
Fixes  #35 