### PR TITLE
Remove old jar if update is successful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Upcoming]
+## [1.2.0] - 2021-06-14
 
 ### Added
 
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Can now download from multiple sites [#27](https://github.com/Senth/minecraft-mod-manager/issues/27)
+- Can now download from multiple sites [#27](https://github.com/Senth/minecraft-mod-manager/issues/27) and [#68](https://github.com/Senth/minecraft-mod-manager/issues/68)
 
   - Because of this, `configure` command has changed; slugs are now set per-site and not globally. Example: `configure dynmap=curse:dynmapforge,modrinth:dynmap`
 
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Mod information is now loaded properly even if it contains character errors [#60](https://github.com/Senth/minecraft-mod-manager/issues/60)
 - Mod information is now loaded properly even if JSON file is not strict [#53](https://github.com/Senth/minecraft-mod-manager/issues/53)
+- Doesn't remove old jar file [#54](https://github.com/Senth/minecraft-mod-manager/issues/54)
 
 ## [1.1.0] - 2021-05-30
 

--- a/minecraft_mod_manager/adapters/repo_impl.py
+++ b/minecraft_mod_manager/adapters/repo_impl.py
@@ -5,6 +5,7 @@ from ..app.configure.configure_repo import ConfigureRepo
 from ..app.install.install_repo import InstallRepo
 from ..app.show.show_repo import ShowRepo
 from ..app.update.update_repo import UpdateRepo
+from ..config import config
 from ..core.entities.mod import Mod
 from ..core.entities.sites import Site, Sites
 from ..core.entities.version_info import VersionInfo
@@ -47,6 +48,10 @@ class RepoImpl(ConfigureRepo, UpdateRepo, InstallRepo, ShowRepo):
 
     def get_all_mods(self) -> Sequence[Mod]:
         return self.mods
+
+    def remove_mod_file(self, filename: str) -> None:
+        path = Path(config.dir).joinpath(filename)
+        path.unlink(missing_ok=True)
 
     def search_for_mod(self, mod: Mod) -> Dict[Sites, Site]:
         sites: Dict[Sites, Site] = {}

--- a/minecraft_mod_manager/app/update/update.py
+++ b/minecraft_mod_manager/app/update/update.py
@@ -27,6 +27,8 @@ class Update(Download):
         self.find_download_and_install(mods_to_update)
 
     def on_version_found(self, download_info: DownloadInfo) -> None:
+        if download_info.mod.file:
+            self._update_repo.remove_mod_file(download_info.mod.file)
         # TODO #32 improve message
         Logger.info(
             f"🟢 Updated -> {download_info.version_info.filename}",

--- a/minecraft_mod_manager/app/update/update_repo.py
+++ b/minecraft_mod_manager/app/update/update_repo.py
@@ -14,3 +14,6 @@ class UpdateRepo(DownloadRepo):
 
     def get_mod(self, id: str) -> Union[Mod, None]:
         raise NotImplementedError()
+
+    def remove_mod_file(self, filename: str) -> None:
+        raise NotImplementedError()


### PR DESCRIPTION
Now removes old jar if the update is successful

### What changed?
- Remove old jar if update is successful

### Testing
- [ ] Added unit tests
- [X] Manual `update`

### Related Issues
Fixes #54 
