### PR TITLE
JSONDecodeError from API response

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,19 +7,18 @@ assignees: ''
 
 ---
 
-### Describe the bug
+### Describe the bug 
 A clear and concise description of what the bug is.
 
 ### Steps to reproduce
 Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. Ran `mcman ...`
+2. Then ran `mcman ...`
 
 ### Expected Behavior
 A clear and concise description of what you expected to happen.
 
 ### Info
  - OS: 
- - minecraft-mod-manager --version:
+ - Python --version: 
+ - minecraft-mod-manager --version: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2021-06-15
+
+### Fixed
+
+- Don't use strict JSON parsing from API response [#79](https://github.com/Senth/minecraft-mod-manager/issues/79)
+
 ## [1.2.1] - 2021-06-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Install and update mods from CurseForge and Modrinth through a simple command.
   - Minecraft version `-v 1.16.4`
   - Fabric/Forge mod `--mod-loader fabric`
 
-## Installation & Requirements
+## Installation/Upgrade & Requirements
 
 1. Requires at least python 3.8
-1. Install with `$ pip install --user minecraft-mod-manager`
+1. Install/Upgrade with `$ pip install --user --upgrade minecraft-mod-manager`
 
 ## Examples
 

--- a/minecraft_mod_manager/gateways/downloader.py
+++ b/minecraft_mod_manager/gateways/downloader.py
@@ -18,7 +18,7 @@ _headers = {"User-Agent": _user_agent}
 class Downloader:
     def get(self, url: str) -> Any:
         with requests.get(url, headers=_headers) as response:
-            return response.json()
+            return response.json(strict=False)
 
     def download(self, url: str, filename: str) -> str:
         """Download the specified mod

--- a/minecraft_mod_manager/gateways/downloader_test.py
+++ b/minecraft_mod_manager/gateways/downloader_test.py
@@ -95,3 +95,18 @@ def test_no_mock_interactions_when_pretending(downloader):
     finally:
         config.pretend = False
         unstub()
+
+
+def test_get_when_non_strict_json(downloader):
+    response = Response()
+    response.encoding = "UTF-8"
+    response.status_code = 200
+    response._content = '\n{"text":"This is\nmy text"}'.encode("UTF-8")
+    expected = {"text": "This is\nmy text"}
+    when(requests).get(...).thenReturn(response)
+
+    result = downloader.get("https://test.com")
+
+    assert expected == result
+
+    unstub()


### PR DESCRIPTION
### What changed?
- Now uses strict=False for API response as well

### Testing
- [X] Added unit tests
- [ ] ...Your own tests...

### Related Issues
Fixes #79
