### PR TITLE
150 fix outdated modrinth api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.6] - 2021-02-21
+
+### Fixed
+
+- Calling Modrinth API resulted in crash due to old User Agent [[#150](https://github.com/Senth/minecraft-mod-manager/issues/150)]
+
 ## [1.2.5] - 2021-10-31
 
 ### Fixed

--- a/minecraft_mod_manager/gateways/api/curse_api.py
+++ b/minecraft_mod_manager/gateways/api/curse_api.py
@@ -15,7 +15,7 @@ class CurseApi(Api):
 
     def get_all_versions(self, mod: Mod) -> List[VersionInfo]:
         versions: List[VersionInfo] = []
-        files = self.downloader.get(CurseApi._make_files_url(mod))
+        files = self.downloader.get(CurseApi._make_files_url(mod), user_agent_fix=True)
         for file in files:
             version = CurseApi._file_to_version_info(file)
             version.name = mod.name
@@ -24,7 +24,7 @@ class CurseApi(Api):
         return versions
 
     def _find_mod_id_by_slug(self, search: str, possible_slugs: Set[str]) -> Union[Tuple[str, str], None]:
-        json = self.downloader.get(CurseApi._make_search_url(search))
+        json = self.downloader.get(CurseApi._make_search_url(search), user_agent_fix=True)
         for curse_mod in json:
             if "slug" in curse_mod and "id" in curse_mod:
                 slug = curse_mod["slug"]

--- a/minecraft_mod_manager/gateways/downloader.py
+++ b/minecraft_mod_manager/gateways/downloader.py
@@ -5,19 +5,22 @@ from typing import Any
 import requests
 from requests.models import Response
 
-# from .. import web_driver
 from ..config import config
 
 _user_agent = (
-    "user-agent=Mozilla/5.0 (Windows NT 6.1; Win64; x64) "
-    + "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
+    "user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    + "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
 )
 _headers = {"User-Agent": _user_agent}
 
 
 class Downloader:
-    def get(self, url: str) -> Any:
-        with requests.get(url, headers=_headers) as response:
+    def get(self, url: str, user_agent_fix: bool = False) -> Any:
+        headers = {}
+        if user_agent_fix:
+            headers = _headers
+
+        with requests.get(url, headers=headers) as response:
             return response.json(strict=False)
 
     def download(self, url: str, filename: str) -> str:

--- a/tests/install_test.py
+++ b/tests/install_test.py
@@ -1,6 +1,6 @@
-from .util.helper import Helper
-
 import pytest
+
+from .util.helper import Helper
 
 
 @pytest.fixture
@@ -41,3 +41,12 @@ def test_remember_slug_for_installed_mod_if_mod_id_varies(helper: Helper):
 
     assert code == 0
     assert helper.exists_in_db("unearthed")
+
+
+def test_install_from_modrinth(helper: Helper):
+    code = helper.run("install", "lithium=modrinth:lithium")
+    lithium_mod = helper.get_mod_in_dir_like("*lithium*.jar")
+    assert lithium_mod is not None
+    assert code == 0
+
+    lithium_mod.unlink()


### PR DESCRIPTION
### What changed?
- Removed "custom" User-Agent when calling Modrinth API
- Updated User-Agent to latest Chrome when calling CurseForge API

### Testing
- [ ] Added unit tests
- [X] Added integration tests: Installing from modrinth
- [ ] ...Your own tests...

### Related Issues
Fixes #150 
