### PR TITLE
Remove bold from --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add official support for python 3.10 when installing with PIP [#160](https://github.com/Senth/minecraft-mod-manager/issues/160)
 
+### Changes
+
+- Remove **bold** from `--version` [#153](https://github.com/Senth/minecraft-mod-manager/issues/153)
+
 ## [1.2.6] - 2022-02-21
 
 ### Fixed

--- a/minecraft_mod_manager/gateways/arg_parser.py
+++ b/minecraft_mod_manager/gateways/arg_parser.py
@@ -74,7 +74,7 @@ def parse_args():
     parser.add_argument(
         "--version",
         action="version",
-        version=f"{config.app_name}: {LogColors.bold}{config.app_version}{LogColors.no_color}",
+        version=f"{config.app_name}: {config.app_version}",
         help="Show application version",
     )
 


### PR DESCRIPTION
Remove **bold** from `--version`. I.e. 1.2.6 instead of **1.2.6**

### Related Issues
Fixes #153 
