### PR TITLE
Handle Ctrl-C by exiting the program without trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash when loading forge mods if they contained inline comments [#146](https://github.com/Senth/minecraft-mod-manager/issues/146)
 - Crash if a mod from Modrith was missing file links [#145](https://github.com/Senth/minecraft-mod-manager/issues/145)
 - Colored output continued to next messages [#141](https://github.com/Senth/minecraft-mod-manager/issues/141)
+- Handles Ctrl-C by stopping the program without printing a stack trace.
+  It can still break the program in an invalid state [#140](https://github.com/Senth/minecraft-mod-manager/issues/140)
 
 ## [1.2.7] - 2022-03-06
 

--- a/minecraft_mod_manager/__main__.py
+++ b/minecraft_mod_manager/__main__.py
@@ -1,3 +1,8 @@
+import signal
+
+from colored import attr, fg
+from tealprint import TealPrint
+
 from .adapters.repo_impl import RepoImpl
 from .app.configure.configure import Configure
 from .app.install.install import Install
@@ -11,7 +16,13 @@ from .gateways.jar_parser import JarParser
 from .gateways.sqlite import Sqlite
 
 
+def signal_handler(signal, frame):
+    TealPrint.error("Exiting...", color=fg("yellow") + attr("bold"), exit=True)
+
+
 def main():
+    signal.signal(signal.SIGINT, signal_handler)
+
     args = parse_args()
     config.add_arg_settings(args)
 


### PR DESCRIPTION
### What changed?
- Ctrl-C now exits the program

### Testing
- [ ] Added unit tests
- [ ] Added integration tests
- [X] Tested manually to make sure that the program exited correctly

### Checklist
- [X] I have reviewed my own code

### Related Issues
Fixes #140
