### PR TITLE
Retry fetch/download if timed out or other reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Colored output continued to next messages [#141](https://github.com/Senth/minecraft-mod-manager/issues/141)
 - Handles Ctrl-C by stopping the program without printing a stack trace.
   It can still break the program in an invalid state [#140](https://github.com/Senth/minecraft-mod-manager/issues/140)
+- Now retries to fetch/download file 5 times before skipping [#169](https://github.com/Senth/minecraft-mod-manager/issues/169)
 
 ## [1.2.7] - 2022-03-06
 

--- a/minecraft_mod_manager/gateways/downloader_test.py
+++ b/minecraft_mod_manager/gateways/downloader_test.py
@@ -4,7 +4,7 @@ from os import path
 
 import pytest
 import requests
-from mockito import mock, unstub, verifyStubbedInvocationsAreUsed, when
+from mockito import mock, unstub, when
 from requests.models import Response
 from requests.structures import CaseInsensitiveDict
 


### PR DESCRIPTION
### What changed?
- Downloader now automatically retries 5 times with exponential backoff

### Testing
- [X] Added unit tests
- [ ] Added integration tests
- [ ] ...Your own tests...

### Checklist
- [x] I have reviewed my own code

### Related Issues
Fixes #169
