### PR TITLE
Checks not only id but slug as well when checking if installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handles Ctrl-C by stopping the program without printing a stack trace.
   It can still break the program in an invalid state [#140](https://github.com/Senth/minecraft-mod-manager/issues/140)
 - Now retries to fetch/download file 5 times before skipping [#169](https://github.com/Senth/minecraft-mod-manager/issues/169)
+- Now identifies installed mods correctly by slug as well [#149](https://github.com/Senth/minecraft-mod-manager/issues/149)
 
 ## [1.2.7] - 2022-03-06
 

--- a/minecraft_mod_manager/adapters/repo_impl.py
+++ b/minecraft_mod_manager/adapters/repo_impl.py
@@ -47,7 +47,14 @@ class RepoImpl(ConfigureRepo, UpdateRepo, InstallRepo, ShowRepo):
         self.db.update_mod(mod)
 
     def is_installed(self, id: str) -> bool:
-        return self.db.exists(id)
+        for mod in self.mods:
+            if mod.id == id:
+                return True
+            elif mod.sites:
+                for site in mod.sites.values():
+                    if site.slug == id:
+                        return True
+        return False
 
     def get_all_mods(self) -> Sequence[Mod]:
         return self.mods


### PR DESCRIPTION
### What changed?
- Now also compares with slug name in addition to mod_id when checking if a mod has been installed

### Testing
- [ ] Added unit tests
- [ ] Added integration tests
- [X] Tested manually as refactoring for DB and repo should be done soon in the future, see #172 

### Checklist
- [ ] I have reviewed my own code

### Related Issues
Fixes #149
