### PR TITLE
When searching on Modrinth, also check slug directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It can still break the program in an invalid state [#140](https://github.com/Senth/minecraft-mod-manager/issues/140)
 - Now retries to fetch/download file 5 times before skipping [#169](https://github.com/Senth/minecraft-mod-manager/issues/169)
 - Now identifies installed mods correctly by slug as well [#149](https://github.com/Senth/minecraft-mod-manager/issues/149)
+- Can now search by slug on Modrinth [[#135](https://github.com/Senth/minecraft-mod-manager/issues/135)].
+  When searching on Modrinth include on their site modrinth.com/mods, searching by slug can return an empty result,
+  so we now get the mod directly by slug.
 
 ## [1.2.7] - 2022-03-06
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ _[(News Archive)](./NEWS.md)_
 | `update -v "1.16.5"`                            | Updates to latest mod version which works with specified MC version.                                |
 | `update -v "1.16.1"`                            | If you upgraded the mods, to a higher version (e.g. snapshot), you can easily downgrade them again. |
 | `configure sodium=modrinth`                     | Change the download site for a mod.                                                                 |
-| `configure sodium=`                             | Reset download sites (downloads from all sites again)                                               |
+| `configure sodium=`                             | Doesn't work, known bug! Reset download sites (downloads from all sites again)                                               |
 | `configure carpet=curse:fabric-carpet`          | Change site slug for a mod.                                                                         |
 | `configure carpet=curse`                        | If you don't define a slug, you will reset the slug for that mod.                                   |
 | `configure sodium=modrinth carpet=curse`        | Easily configure multiple mods at the same time.                                                    |

--- a/minecraft_mod_manager/app/configure/configure.py
+++ b/minecraft_mod_manager/app/configure/configure.py
@@ -30,7 +30,7 @@ class Configure:
                 )
                 return
 
-            if isinstance(mod_arg.sites, dict):
+            if len(mod_arg.sites) > 0:
                 Configure._update_sites(found_mod, mod_arg.sites)
 
             # Updating mod
@@ -53,7 +53,7 @@ class Configure:
         old_sites = mod.sites
         mod.sites = sites
 
-        if old_sites:
+        if len(old_sites) > 0:
             for old_site in old_sites.values():
                 if old_site.id:
                     if mod.sites and old_site.name in mod.sites:

--- a/minecraft_mod_manager/app/configure/configure_test.py
+++ b/minecraft_mod_manager/app/configure/configure_test.py
@@ -61,10 +61,10 @@ def test_abort_before_configuring_when_later_mod_not_found(mock_repo):
             Mod("carpet", "", {Sites.curse: Site(Sites.curse)}),
         ),
         (
-            "Mod sites remove when no is specified",
+            "Mod sites keep when no is specified",
             Mod("carpet", "", {Sites.modrinth: Site(Sites.modrinth)}),
             [ModArg("carpet", {})],
-            Mod("carpet", "", {}),
+            Mod("carpet", "", {Sites.modrinth: Site(Sites.modrinth)}),
         ),
         (
             "Keep old info if no site is specified",

--- a/minecraft_mod_manager/core/entities/mod.py
+++ b/minecraft_mod_manager/core/entities/mod.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, Set, Union
+from typing import Dict, Optional, Set
 
 from .mod_loaders import ModLoaders
 from .sites import Site, Sites
@@ -10,7 +10,7 @@ from .sites import Site, Sites
 class ModArg:
     """Mod argument from the CLI"""
 
-    def __init__(self, id: str, sites: Union[Dict[Sites, Site], None] = None) -> None:
+    def __init__(self, id: str, sites: Dict[Sites, Site] = {}) -> None:
         self.sites = sites
         """Where the mod is downloaded from"""
         self.id = id
@@ -70,9 +70,9 @@ class Mod(ModArg):
         self,
         id: str,
         name: str,
-        sites: Union[Dict[Sites, Site], None] = None,
-        version: Union[str, None] = None,
-        file: Union[str, None] = None,
+        sites: Dict[Sites, Site] = {},
+        version: Optional[str] = None,
+        file: Optional[str] = None,
         upload_time: int = 0,
         mod_loader: ModLoaders = ModLoaders.unknown,
     ):

--- a/minecraft_mod_manager/gateways/api/modrinth_api_test.py
+++ b/minecraft_mod_manager/gateways/api/modrinth_api_test.py
@@ -11,7 +11,7 @@ from ...core.entities.sites import Site, Sites
 from ...core.entities.version_info import Stabilities, VersionInfo
 from ...core.errors.mod_not_found_exception import ModNotFoundException
 from ..http import Http
-from .modrinth_api import ModrinthApi
+from .modrinth_api import ModrinthApi, _base_url
 
 testdata_dir = Path(__file__).parent.joinpath("testdata").joinpath("modrinth_api")
 search_result_file = testdata_dir.joinpath("search_fabric-api.json")
@@ -70,8 +70,34 @@ def mod(id="fabric-api", name="Fabric API", site_slug="fabric-api", site_id=site
     return Mod(id=id, name=name, sites={Sites.modrinth: Site(Sites.modrinth, site_id, site_slug)}, file=file)
 
 
-def test_search_mod(api: ModrinthApi, search_result):
-    when(api.http).get(...).thenReturn(search_result)
+def test_search_mod(api: ModrinthApi, search_result, mod_info):
+    when(api.http).get(ModrinthApi._make_search_url("search-slug")).thenReturn(search_result)
+    when(api.http).get(_base_url + "/mod/search-slug").thenReturn(mod_info)
+    expected = [
+        Site(Sites.modrinth, "P7dR8mSH", "fabric-api"),
+        Site(Sites.modrinth, "720sJXM2", "bineclaims"),
+        Site(Sites.modrinth, "iA9GjB4v", "BoxOfPlaceholders"),
+        Site(Sites.modrinth, "ZfVQ3Rjs", "mealapi"),
+        Site(Sites.modrinth, "MLYQ9VGP", "cardboard"),
+        Site(Sites.modrinth, "meZK2DCX", "dawn"),
+        Site(Sites.modrinth, "ssUbhMkL", "gravestones"),
+        Site(Sites.modrinth, "BahnQObN", "chat-icon-api"),
+        Site(Sites.modrinth, "oq1VV8nB", "splashesAPI"),
+        Site(Sites.modrinth, "gno5mxtx", "grand-economy"),
+        Site(Sites.modrinth, "aC3cM3Vq", "mouse-tweaks"),
+    ]
+
+    actual = api.search_mod("search-slug")
+
+    verifyStubbedInvocationsAreUsed()
+    unstub()
+
+    assert expected == actual
+
+
+def test_search_mod_with_get_mod_info_for_slug(api: ModrinthApi, search_result):
+    when(api.http).get(ModrinthApi._make_search_url("search-slug")).thenReturn(search_result)
+    when(api.http).get(_base_url + "/mod/search-slug").thenReturn("")
     expected = [
         Site(Sites.modrinth, "P7dR8mSH", "fabric-api"),
         Site(Sites.modrinth, "720sJXM2", "bineclaims"),
@@ -85,7 +111,7 @@ def test_search_mod(api: ModrinthApi, search_result):
         Site(Sites.modrinth, "gno5mxtx", "grand-economy"),
     ]
 
-    actual = api.search_mod("search string")
+    actual = api.search_mod("search-slug")
 
     verifyStubbedInvocationsAreUsed()
     unstub()

--- a/minecraft_mod_manager/gateways/sqlite.py
+++ b/minecraft_mod_manager/gateways/sqlite.py
@@ -31,7 +31,7 @@ class _Column:
         self.active = bool(active)
 
     @staticmethod
-    def string_sites_to_dict(full_str: str) -> Union[Dict[Sites, Site], None]:
+    def string_sites_to_dict(full_str: str) -> Dict[Sites, Site]:
         if "," in full_str:
             sites_strings = full_str.split(",")
         else:
@@ -56,9 +56,6 @@ class _Column:
                 sites[name] = Site(name, id, slug)
             except KeyError:
                 TealPrint.error(f"DB site {site_str} not a valid site, full: '{full_str}'")
-
-        if not sites:
-            return None
 
         return sites
 
@@ -145,7 +142,7 @@ class Sqlite:
                 mod.upload_time = db_mod.upload_time
 
                 # Update new mod sites info
-                if isinstance(mod.sites, dict):
+                if len(mod.sites) > 0:
                     self.update_mod(mod)
                 else:
                     mod.sites = db_mod.sites

--- a/tests/install_test.py
+++ b/tests/install_test.py
@@ -72,3 +72,11 @@ def test_install_dependencies(helper: Helper):
     assert code == 0
     assert lamba_better_crass is not None
     assert dependency_fabric_api is not None
+
+
+def test_install_dcch(helper: Helper):
+    code = helper.run("install", "dcch")
+    dcch = helper.get_mod_in_dir_like("dcch*.jar")
+
+    assert code == 0
+    assert dcch is not None

--- a/tests/install_test.py
+++ b/tests/install_test.py
@@ -76,7 +76,7 @@ def test_install_dependencies(helper: Helper):
 
 def test_install_dcch(helper: Helper):
     code = helper.run("install", "dcch")
-    dcch = helper.get_mod_in_dir_like("dcch*.jar")
+    dcch = helper.get_mod_in_dir_like("DCCH*.jar")
 
     assert code == 0
     assert dcch is not None


### PR DESCRIPTION
In Modrinth you can get the mod either by mod_id (site_id) or directly by slug,
as search results don't return any results when using the slug,

Fixes #135

### What changed?
- When searching on modrinth we not only search by `/mod?query=` but also check if we can find the mod directly by the slug on `/mod/slug`

### Testing
- [X] Added unit tests
- [X] Added integration tests
- [ ] ...Your own tests...

### Checklist
- [ ] I have reviewed my own code

### Related Issues
Fixes #135
