### PR TITLE
Fix removed unknown mod loaders from Modrinth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## `1.4.2` - 2022-08-27: Download correct modloader
+
+### Fixed
+
+- Downloading correct mod loader.
+  When downloading from Modrinth, mod loaders like quilt and bukkit were removed instead of registered as unknown. [#202](https://github.com/Senth/minecraft-mod-manager/issues/202)
+
 ## `1.4.1` - 2022-08-02: Fix modrinth bug
 
 ### Fixed

--- a/minecraft_mod_manager/core/entities/mod_loaders.py
+++ b/minecraft_mod_manager/core/entities/mod_loaders.py
@@ -7,6 +7,11 @@ class ModLoaders(Enum):
     unknown = "unknown"
     fabric = "fabric"
     forge = "forge"
+    quilt = "quilt"
+    bukkit = "bukkit"
+    paper = "paper"
+    purpur = "purpur"
+    spigot = "spigot"
 
     @staticmethod
     def from_name(name: str) -> ModLoaders:

--- a/minecraft_mod_manager/gateways/api/api.py
+++ b/minecraft_mod_manager/gateways/api/api.py
@@ -1,8 +1,7 @@
 from datetime import datetime
-from typing import List, Set
+from typing import List
 
 from ...core.entities.mod import Mod
-from ...core.entities.mod_loaders import ModLoaders
 from ...core.entities.sites import Site, Sites
 from ...core.entities.version_info import VersionInfo
 from ..http import Http
@@ -35,12 +34,3 @@ class Api:
             date = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S%z")
 
         return round(date.timestamp())
-
-    @staticmethod
-    def _to_mod_loaders(loaders: List[str]) -> Set[ModLoaders]:
-        mod_loaders: Set[ModLoaders] = set()
-
-        for loader in loaders:
-            mod_loaders.add(ModLoaders.from_name(loader))
-
-        return mod_loaders

--- a/minecraft_mod_manager/gateways/api/api.py
+++ b/minecraft_mod_manager/gateways/api/api.py
@@ -41,10 +41,6 @@ class Api:
         mod_loaders: Set[ModLoaders] = set()
 
         for loader in loaders:
-            loader = loader.lower()
-            if loader == "fabric":
-                mod_loaders.add(ModLoaders.fabric)
-            elif loader == "forge":
-                mod_loaders.add(ModLoaders.forge)
+            mod_loaders.add(ModLoaders.from_name(loader))
 
         return mod_loaders

--- a/minecraft_mod_manager/gateways/api/modrinth_api.py
+++ b/minecraft_mod_manager/gateways/api/modrinth_api.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from tealprint import TealPrint
 
@@ -104,7 +104,7 @@ class ModrinthApi(Api):
     def _json_to_version_info(data: Any) -> VersionInfo:
         return VersionInfo(
             stability=Stabilities.from_name(data["version_type"]),
-            mod_loaders=Api._to_mod_loaders(data["loaders"]),
+            mod_loaders=ModrinthApi._to_mod_loaders(data["loaders"]),
             site=Sites.modrinth,
             upload_time=Api._to_epoch_time(data["date_published"]),
             minecraft_versions=data["game_versions"],
@@ -145,3 +145,12 @@ class ModrinthApi(Api):
         if json and "mod_id" in json:
             return str(json["mod_id"])
         return ""
+
+    @staticmethod
+    def _to_mod_loaders(loaders: List[str]) -> Set[ModLoaders]:
+        mod_loaders: Set[ModLoaders] = set()
+
+        for loader in loaders:
+            mod_loaders.add(ModLoaders.from_name(loader))
+
+        return mod_loaders

--- a/tests/install_test.py
+++ b/tests/install_test.py
@@ -82,3 +82,11 @@ def test_install_dcch(helper: Helper):
 
     assert code == 0
     assert dcch is not None
+
+
+def test_install_fabric_version(helper: Helper):
+    code = helper.run("-v", "1.16.5", "--mod-loader", "fabric", "--alpha", "install", "simple-voice-chat")
+    smc = helper.get_mod_in_dir_like("voicechat*.jar")
+
+    assert code == 0
+    assert smc is None


### PR DESCRIPTION
### What changed?
- Added other mod loaders
- When converting mod loaders from Modrinth, it now uses unknown if the mod loader is not found.

### Testing
- [ ] Added unit tests
- [X] Added integration tests
- [ ] ...Your own tests...

### Checklist
- [x] I have reviewed my own code

### Related Issues
Fixes #202 
